### PR TITLE
Pass driver info to Timestream using user agent

### DIFF
--- a/src/odbc/src/connection.cpp
+++ b/src/odbc/src/connection.cpp
@@ -699,7 +699,8 @@ bool Connection::TryRestoreConnection(const config::Configuration& cfg,
                 << cfg.GetRegion() << ", connection timeout is "
                 << clientCfg.connectTimeoutMs << ", request timeout is "
                 << clientCfg.requestTimeoutMs << ", max connection is "
-                << clientCfg.maxConnections);
+                << clientCfg.maxConnections << ", user agent is "
+                << clientCfg.userAgent);
 
   SetClientProxy(clientCfg);
 


### PR DESCRIPTION
### Summary
Pass ODBC driver info to Timestream
<!--- General summary / title -->

### Description

<!--- Details of what you changed -->
Driver info is passed to Timestream using user agent when the connection is created.

The driver info format is like this `ts-odbc.Driver_version on platform`

For example for Windows it is `ts-odbc-2.0.0 on Windows`

### Tests performed

- As this change could impact connection setup, run all tests on Windows, macOS and Linux to ensure they could succeed. 

> All tests passed successfully.

- Do manual test on Windows, Linux and macOS. Setting log level to debug, create an ODBC connection on Windows/macOS/Linux. Search log for "user agent is", found below info for them. 

> All user agent strings match expected values.

> --windows
> ```
> TID: 24688 16:07:36 07/21/23 DEBUG MSG:  connection.cpp:703 timestream::odbc::Connection::TryRestoreConnection: region is us-west-2, connection timeout is 1000, request timeout is 3000, max connection is 25, user agent is ts-odbc.02.00.0000 on Windows
> ```

> --macOS
> ```
> TID: 0x104f72e00 16:29:09 21/07/2023 DEBUG MSG:  connection.cpp:703 TryRestoreConnection: region is us-west-2, connection timeout is 1000, request timeout is 3000, max connection is 25, user agent is ts-odbc.02.00.0000 on macOS
> ```

> --linux
> ```
> TID: 140259671618624 23:33:22 07/21/23 DEBUG MSG:  connection.cpp:698 TryRestoreConnection: region is us-west-2, connection timeout is 1000, request timeout is 3000, max connection is 25, user agent is ts-odbc.02.00.0000 on Linux
> ```

### Related Issue

<!--- Link to issue where this is tracked -->

### Additional Reviewers

<!-- Any additional reviewers -->
@alexey-temnikov 