### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Read VERSION file
       if: ${{ env.SIGNING_ENABLED == 'true' }}
       id: getversion
-      run: echo "::set-output name=version::$(cat src/ODBC_DRIVER_VERSION.txt)"
+      run: echo "version=$(cat src/ODBC_DRIVER_VERSION.txt)" >> "$GITHUB_OUTPUT"
 
     - name: "Configure AWS credentials"
       if: ${{ env.SIGNING_ENABLED == 'true' }}
@@ -315,7 +315,7 @@ jobs:
     - name: Read VERSION file
       if: ${{ env.SIGNING_ENABLED == 'true' }}
       id: getversion
-      run: echo "::set-output name=version::$(cat src/ODBC_DRIVER_VERSION.txt)"
+      run: echo "version=$(cat src/ODBC_DRIVER_VERSION.txt)" >> "$GITHUB_OUTPUT"
 
     - name: "Configure AWS credentials"
       if: ${{ env.SIGNING_ENABLED == 'true' }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter