### PR TITLE
Add OLE DB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,6 @@ CMakeCache.txt
 /src/PowerBIConnector/AmazonTimestreamAADConnector/.vs/
 src/aws-sdk-cpp/
 src/tests/input/credentials
+src/out/
 scripts/postinst_unix32.sh
 scripts/postinst_unix64.sh

--- a/docs/markdown/setup/developer-guide.md
+++ b/docs/markdown/setup/developer-guide.md
@@ -40,14 +40,14 @@ C/C++ usage and formatting.
 
 - AWS Logs
 
-  This ODBC driver uses AWS logs beside its own logging. Please see how AWS Logs work in their [official document](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/logging.html). The logs will be stored inthe executable directory following the default naming pattern of `aws_sdk_<date>.log`.
+  This ODBC driver uses AWS logs beside its own logging. Please see how AWS Logs work in their [official document](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/logging.html). The logs will be stored in the executable directory following the default naming pattern of `aws_sdk_<date>.log`.
 
 ### Test Data
 Test data are needed for tests to run successfully and they only need to be loaded once for each AWS account. Check [here](#data-population-for-testing) for instructions on loading the test data.
 
 ## Windows
 
-1. Microsoft Visual Studio (Community 2019 Verified)
+1. Microsoft Visual Studio (Community 2022 Verified)
    1. Desktop Development for C++
    2. Visual Studio core editor
    3. C++ ATL for latest v142 build tools (x86 & x64)
@@ -446,18 +446,18 @@ Reading and writing data on Timestream requires corresponding permissions. For r
 ## Integration Tests
 
 ### IAM Profile Tests
-1. The IAM profile tests are disabled by default because they require valid IAM profiles. They can be enabled by exporting environment variable `ENABLE_PROFILE_TEST` to `true`. Follow below instructions for setting up valid IAM profiles and required environmenr variables. 
+1. The IAM profile tests are disabled by default because they require valid IAM profiles. They can be enabled by exporting environment variable `ENABLE_PROFILE_TEST` to `true`. Follow below instructions for setting up valid IAM profiles and required environment variables. 
 #### Windows
-1. `cd` to repository root. Set environment variable REPOSITORY_ROOT to your repository root.
+1. `cd` to repository root. Set the environment variable `REPOSITORY_ROOT` to your repository root.
 2. Run `.\src\tests\input\create_credentials_file.ps1` to create credential files for testing. Note that this script will write AWS IAM credentials file `src\tests\input\credentials`.
 3. Set environment variable AWS_SHARED_CREDENTIALS_FILE to the newly created credentials file.
 
 #### Linux or macOS
-1. `cd` to repository root. Set environment variable REPOSITORY_ROOT to your repository root
+1. `cd` to repository root. Set environment variable `REPOSITORY_ROOT` to your repository root
 
     `export REPOSITORY_ROOT=<your repository root>`
 2. Run `./src/tests/input/create_credentials_file.sh` from the respository root to create credential files for testing. Note that this script will write AWS IAM credentials file `src/tests/input/credentials`.
-3. Set environment variable AWS_SHARED_CREDENTIALS_FILE to the newly created credentials file.
+3. Set environment variable `AWS_SHARED_CREDENTIALS_FILE` to the newly created credentials file.
 
     `export AWS_SHARED_CREDENTIALS_FILE=$REPOSITORY_ROOT/src/tests/input/credentials`
 
@@ -478,9 +478,9 @@ Reading and writing data on Timestream requires corresponding permissions. For r
    | `AAD_CLIENT_SECRET`  | AADClientSecret                        |
 
 ### Okta Authentication Tests
-1. The Okta authentication tests are disabled by default because they require a valid Okta test account. They can be enabled by exporting environment variable `ENABLE_OKTA_TEST` to `true`.
+1. The Okta authentication tests are disabled by default because they require a valid Okta test account. They can be enabled by exporting the environment variable `ENABLE_OKTA_TEST` with the value `true`.
 
-2. To run Okta authentication test, the environment variables in the following table need to be configured with correct values.  Refer to [Okta Authentication Setup Guide](Okta-setup.md) for instructions on setting up an Okta authentication.
+2. To run the Okta authentication tests, the environment variables in the following table need to be configured with correct values.  Refer to [Okta Authentication Setup Guide](Okta-setup.md) for instructions on setting up an Okta authentication.
 
    | Variable Name |  Corresponding Connection String Option   |
    |---------------|-------------------------------------------|
@@ -493,7 +493,7 @@ Reading and writing data on Timestream requires corresponding permissions. For r
 Ensure `OKTA_HOST` does not include `https://` or `http://`.
 
 ### Big Table Pagination Tests
-Big table pagination tests are time-consuming. To save time for integration test， they are disabled by default. They could be enabled by export environment variable `BIG_TABLE_PAGINATION_TEST_ENABLE` to `true`.
+Big table pagination tests are time-consuming. To save time for integration test, they are disabled by default. They can be enabled by exporting the environment variable `BIG_TABLE_PAGINATION_TEST_ENABLE` with the value `true`.
 
 ### Proxy Manual Test on Windows
 For setting up connection proxy properties, see [connection proxy guide.](connection-proxy-guide.md).
@@ -504,8 +504,8 @@ For setting up connection proxy properties, see [connection proxy guide.](connec
 3. Run proxy server at port 9999
    `cd proxy-test-server/examples`
    `node proxy.js`
-4. Set environment variable TS_PROXY_HOST, TS_PROXY_PORT and TS_PROXY_SCHEME.
-5. Start DSN window and create a connection to Timestream. Click 'Test' button to verify.
+4. Set environment variables `TS_PROXY_HOST`, `TS_PROXY_PORT`, and `TS_PROXY_SCHEME`.
+5. Start DSN window and create a connection to Timestream. Click the 'Test' button to verify.
 
 ## Test Results
 Unit test results can be viewed in `odbc_unit_test_result.xml` and integration test results can be viewed in `odbc_test_result.xml`.

--- a/docs/markdown/setup/ole-db.md
+++ b/docs/markdown/setup/ole-db.md
@@ -1,0 +1,56 @@
+# OLE DB Setup and Support
+
+The [OLE DB to ODBC bridge](https://learn.microsoft.com/en-us/sql/ado/guide/appendixes/microsoft-ole-db-provider-for-odbc?view=sql-server-ver15) can be used with the Amazon Timestream ODBC driver.
+
+## PowerShell Example
+
+Given that the driver has been installed and a DSN has been configured, OLE DB can be used with the driver by running the following PowerShell script, on Windows:
+
+```powershell
+$connectionString = "DSN=Timestream DSN;"
+
+$query = "SELECT * FROM my_db.my_table LIMIT 10"
+
+$connection = New-Object -ComObject ADODB.Connection
+$connection.Open($connectionString)
+
+$command = New-Object -ComObject ADODB.Command
+$command.ActiveConnection = $connection
+$command.CommandText = $query
+
+$recordset = $command.Execute()
+
+if ($recordset) {
+	while (!$recordset.EOF) {
+		$rowData = ""
+		for ($i = 0; $i -lt $recordset.Fields.Count; $i++) {
+			$field = $recordset.Fields.Item($i)
+			$fieldValue = $field.Value
+			if ($fieldValue -is [System.DBNull]) {
+				$fieldValue = "-"
+			}
+			$rowData += "$($field.Name): $($fieldValue)"
+			if ($i -lt $recordset.Fields.Count - 1) {
+				$rowData += " | "
+			}
+		}
+		Write-Output $rowData
+		Write-Output ""
+    	$recordset.MoveNext()
+	}
+	$recordset.Close()
+}
+
+$connection.Close()
+```
+
+The script executes a query using ADODB (indirectly OLE DB) and loops through the results, printing each column separated by `|` with its name and the `-` character to represent null values. Replace "Timestream DSN" with your DSN and replace the query with a valid query.
+
+## Excel Example
+
+OLE DB with the Amazon Timestream ODBC driver can be used with Excel by using the Power Pivot add-in. See [this Microsoft guide](https://support.microsoft.com/en-us/office/start-the-power-pivot-add-in-for-excel-a891a66d-36e3-43fc-81e8-fc4798f39ea8) for how to install the Power Pivot add-in.
+
+Once Power Pivot is installed, in Excel:
+1. Go to **Data** and click on **Manage Data Model** to open a new window for Power Pivot.
+2. In Power Pivot, choose **From Other Sources** and then select **Others(OLEDB/ODBC)** and choose **Next**.
+3. Finally, choose **Build** for your connection string and select **Microsoft OLE DB Provider for ODBC Drivers** and select your Timestream DSN.

--- a/docs/markdown/support/odbc-support-and-limitations.md
+++ b/docs/markdown/support/odbc-support-and-limitations.md
@@ -317,6 +317,7 @@ In both `SQLSetStmtAttr` and `SQLGetStmtAttr`
 |SQL_ATTR_METADATA_ID|SQL_FALSE| yes |
 |SQL_ATTR_PARAM_BIND_TYPE| SQL_BIND_BY_COLUMN | no |
 |SQL_ATTR_ROW_ARRAY_SIZE| 1 | yes |
+|SQL_ROWSET_SIZE| 1 | yes |
 |SQL_ATTR_ROW_BIND_OFFSET_PTR| column bind offset pointer | yes |
 |SQL_ATTR_ROW_BIND_TYPE| SQL_BIND_BY_COLUMN | no |
 |SQL_ATTR_ROW_STATUS_PTR| row status pointer | yes| 
@@ -435,7 +436,7 @@ Wrapped in "()". Each element is separated by ",".
 (1,2,3)
 ```
 
-For null it could only be fetched as a string and the result is "-".
+Null values are represented with an empty string within arrays.
 
 Please refer to [Timestream Data Types](https://docs.aws.amazon.com/timestream/latest/developerguide/supported-data-types.html) for more info.
 

--- a/src/odbc/include/timestream/odbc/app/application_data_buffer.h
+++ b/src/odbc/include/timestream/odbc/app/application_data_buffer.h
@@ -116,8 +116,26 @@ class ApplicationDataBuffer {
    *
    * @param offset Offset.
    */
-  void SetByteOffset(int offset) {
+  void SetByteOffset(SqlUlen offset) {
     this->byteOffset = offset;
+  }
+
+  /**
+   * Get the current cell offset.
+   * 
+   * @return Cell offset.
+   */
+  SqlLen GetCellOffset() {
+    return this->cellOffset;
+  }
+
+  /**
+   * Set cell offset for the current cell.
+   * 
+   * @param offset Offset
+   */
+  void SetCellOffset(SqlLen offset) {
+    this->cellOffset = offset;
   }
 
   /**
@@ -248,7 +266,7 @@ class ApplicationDataBuffer {
    * @param written Number of written characters.
    * @return Conversion result.
    */
-  ConversionResult::Type PutString(const std::string& value, int32_t& written);
+  ConversionResult::Type PutString(const std::string& value, SqlLen& written);
 
   /**
    * Put NULL.
@@ -537,7 +555,7 @@ class ApplicationDataBuffer {
    */
   template < typename OutCharT, typename InCharT >
   ConversionResult::Type PutStrToStrBuffer(
-      const std::basic_string< InCharT >& value, int32_t& written);
+      const std::basic_string< InCharT >& value, SqlLen& written);
 
   /**
    * Put raw data to any buffer.
@@ -548,7 +566,7 @@ class ApplicationDataBuffer {
    * @return Conversion result.
    */
   ConversionResult::Type PutRawDataToBuffer(const void* data, size_t len,
-                                            int32_t& written);
+                                            SqlLen& written);
 
   /**
    * Get int of type T.
@@ -616,7 +634,10 @@ class ApplicationDataBuffer {
   SqlLen* reslen;
 
   /** Current byte offset */
-  int byteOffset;
+  size_t byteOffset;
+
+  /** Current cell offset, meaning byte offset within a cell */
+  SqlLen cellOffset;
 
   /** Current element offset. */
   SqlUlen elementOffset;

--- a/src/odbc/include/timestream/odbc/connection.h
+++ b/src/odbc/include/timestream/odbc/connection.h
@@ -52,8 +52,9 @@ struct StatementAttributes {
   SqlUlen bindType;
   SqlUlen concurrency;
   SqlUlen cursorType;
-  SqlUlen retrievData;
+  SqlUlen retrieveData;
   SqlUlen rowsetSize;
+  SqlUlen rowArraySize;
 };
 
 /**
@@ -636,7 +637,14 @@ class IGNITE_IMPORT_EXPORT Connection : public diagnostic::DiagnosableAdapter {
   std::map< const Statement*, std::string > cursorNameMap_;
 
   /** statement attributes struct */
-  StatementAttributes stmtAttr_;
+  StatementAttributes stmtAttr_ = {
+    SQL_PARAM_BIND_BY_COLUMN, // bindType
+    SQL_CONCUR_READ_ONLY,     // concurrency
+    SQL_CURSOR_FORWARD_ONLY,  // cursorType
+    SQL_RD_OFF,               // retrieveData
+    1,                        // rowsetSize
+    1,                        // rowArraySize
+  };
 };
 }  // namespace odbc
 }  // namespace timestream

--- a/src/odbc/include/timestream/odbc/descriptor.h
+++ b/src/odbc/include/timestream/odbc/descriptor.h
@@ -38,6 +38,7 @@ struct DescriptorHeader {
   SQLLEN* bindOffsetPtr;
   SQLINTEGER bindType;
   SQLSMALLINT count;
+  SQLULEN rowsetSize;
   SQLULEN* rowsProcessedPtr;
 };
 

--- a/src/odbc/include/timestream/odbc/statement.h
+++ b/src/odbc/include/timestream/odbc/statement.h
@@ -66,18 +66,31 @@ class IGNITE_IMPORT_EXPORT Statement : public diagnostic::DiagnosableAdapter {
                   SqlLen bufferLength, SqlLen* strLengthOrIndicator);
 
   /**
+   * Fetch specified rowset of data from the result set and returns data
+   * for all bound columns. Rowsets can be specified at an absolute or
+   * relative position; bookmarks are not supported.
+   *
+   * @param orientation SQLUSMALLINT Type of fetch.
+   * @param offset SQLLEN Number of the row to fetch.
+   * @param rowCount SQLULEN* Pointer to a buffer in which to return the number of
+   *    rows actually fetched.
+   * @param rowStatusArray SQLUSMALLINT* Pointer to an array in which to return the status of each row.
+   */
+  void ExtendedFetch(SQLUSMALLINT orientation, SQLLEN offset, SQLULEN* rowCount, SQLUSMALLINT* rowStatusArray);
+
+  /**
    * Set column binding offset pointer.
    *
    * @param ptr Column binding offset pointer.
    */
-  void SetColumnBindOffsetPtr(int* ptr);
+  void SetColumnBindOffsetPtr(SqlUlen* ptr);
 
   /**
    * Get column binding offset pointer.
    *
    * @return Column binding offset pointer.
    */
-  int* GetColumnBindOffsetPtr();
+  SqlUlen* GetColumnBindOffsetPtr();
 
   /**
    * Get number of columns in the result set.
@@ -320,7 +333,35 @@ class IGNITE_IMPORT_EXPORT Statement : public diagnostic::DiagnosableAdapter {
   SQLUSMALLINT* GetRowStatusesPtr();
 
   /**
-   * Set current active ARD descriptor
+   * Get the cell offset for the current column.
+   * 
+   * @return Cell offset.
+   */
+  SqlLen GetCellOffset();
+
+  /**
+   * Set cell offset.
+   * 
+   * @param offset The new offset value.
+   */
+  void SetCellOffset(SqlLen offset);
+
+  /**
+   * Get the current column number.
+   * 
+   * @return Current column number.
+   */
+  SQLUSMALLINT GetCurrentColNum();
+
+  /**
+   * Set the current column number.
+   * 
+   * @param colNum SQLUSMALLINT The new current column number.
+   */
+  void SetCurrentColNum(SQLUSMALLINT colNum);
+
+  /**
+   * Set current active ARD descriptor.
    *
    * @param desc Descriptor pointer.
    */
@@ -473,6 +514,21 @@ class IGNITE_IMPORT_EXPORT Statement : public diagnostic::DiagnosableAdapter {
                                         app::ApplicationDataBuffer& buffer);
 
   /**
+   * Fetch specified rowset of data from the result set and returns data
+   * for all bound columns. Rowsets can be specified at an absolute or
+   * relative position; bookmarks are not supported.
+   * 
+   * @param orientation SQLUSMALLINT Type of fetch.
+   * @param offset SQLLEN Number of the row to fetch.
+   * @param rowCount SQLULEN* Pointer to a buffer in which to return the number of
+   *    rows actually fetched.
+   * @param rowStatusArray SQLUSMALLINT* Pointer to an array in which to return the status of each row.
+   * @return Operation result.
+   */
+  SqlResult::Type InternalExtendedFetch(SQLUSMALLINT orientation, SQLLEN offset,
+                                        SQLULEN* rowCount, SQLUSMALLINT* rowStatusArray);
+
+  /**
    * Free resources
    * @param option indicates what needs to be freed
    * @return Operation result.
@@ -482,10 +538,11 @@ class IGNITE_IMPORT_EXPORT Statement : public diagnostic::DiagnosableAdapter {
   /**
    * Close statement.
    * Internal call.
-   *
+   * 
+   * @param bool ignoreErrors Whether to ignore all errors.
    * @return Operation result.
    */
-  SqlResult::Type InternalClose();
+  SqlResult::Type InternalClose(bool ignoreErrors);
 
   /**
    * Process internal SQL command.
@@ -703,10 +760,19 @@ class IGNITE_IMPORT_EXPORT Statement : public diagnostic::DiagnosableAdapter {
   SQLUSMALLINT* rowStatuses;
 
   /** Offset added to pointers to change binding of column data. */
-  int* columnBindOffset;
+  SqlUlen* columnBindOffset;
+
+  /** Offset used to iterate through a cell for variable-length data. */
+  SqlLen cellOffset;
+
+  /** The current column number. Used in SQLGetData. */
+  SqlUlen currentColNum;
 
   /** Row array size. */
   SqlUlen rowArraySize;
+
+  /** Rowset size. */
+  SqlUlen rowsetSize;
 
   /** implicitly allocated ARD */
   std::unique_ptr< Descriptor > ardi;

--- a/src/odbc/include/timestream/odbc/utility.h
+++ b/src/odbc/include/timestream/odbc/utility.h
@@ -64,7 +64,6 @@ T* GetPointerWithOffset(T* ptr, size_t offset) {
  * return value(bytes):
  *   - 0, if the inBuffer is nullptr or outBufferLenBytes is 0 but outBuffer is
  * not nullptr
- *   - the required output buffer length, if outBuffer is nullptr
  *   - copied bytes number, if outBuffer is not nullptr and outBufferLenBytes
  *   is not 0
  */
@@ -83,7 +82,6 @@ CopyUtf8StringToSqlCharString(const char* inBuffer, SQLCHAR* outBuffer,
  * return value(bytes):
  *   - 0, if the inBuffer is nullptr or outBufferLenBytes is 0 but outBuffer is
  * not nullptr
- *   - the required output buffer length, if outBuffer is nullptr
  *   - copied bytes number, if outBuffer is not nullptr and outBufferLenBytes
  *   is not 0
  */

--- a/src/odbc/src/connection.cpp
+++ b/src/odbc/src/connection.cpp
@@ -1401,17 +1401,10 @@ SqlResult::Type Connection::InternalSetStmtAttribute(SQLUSMALLINT option,
 
         return SqlResult::AI_ERROR;
       }
-      stmtAttr_.retrievData = value;
+      stmtAttr_.retrieveData = value;
       break;
     }
     case SQL_ROWSET_SIZE: {
-      if (value > 1000) {
-        AddStatusRecord(
-            SqlState::SIM001_FUNCTION_NOT_SUPPORTED,
-            "Array size value cannot be set to a value other than 1000");
-
-        return SqlResult::AI_ERROR;
-      }
       stmtAttr_.rowsetSize = value;
       break;
     }

--- a/src/odbc/src/odbc.cpp
+++ b/src/odbc/src/odbc.cpp
@@ -526,15 +526,18 @@ SQLRETURN SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT orientation,
                            SQLUSMALLINT* rowStatusArray) {
   LOG_DEBUG_MSG("SQLExtendedFetch called");
 
-  SQLRETURN res = SQLFetchScroll(stmt, orientation, offset);
+  Statement* statement = reinterpret_cast< Statement* >(stmt);
 
-  if (res == SQL_SUCCESS) {
-    if (rowCount)
-      *rowCount = 1;
+  if (!statement) {
+      LOG_ERROR_MSG("statement is nullptr");
+      return SQL_INVALID_HANDLE;
+  }
 
-    if (rowStatusArray)
-      rowStatusArray[0] = SQL_ROW_SUCCESS;
-  } else if (res == SQL_NO_DATA && rowCount)
+  statement->ExtendedFetch(orientation, offset, rowCount, rowStatusArray);
+
+  SQLRETURN res = statement->GetDiagnosticRecords().GetReturnCode();
+
+  if (res == SQL_NO_DATA && rowCount)
     *rowCount = 0;
 
   LOG_DEBUG_MSG("res is " << res);
@@ -1182,7 +1185,18 @@ SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT colNum, SQLSMALLINT targetType,
   ApplicationDataBuffer dataBuffer(driverType, targetValue, bufferLength,
                                    strLengthOrIndicator);
 
+  // Cell offsets are used between SQLGetData calls to return
+  // variable-length data in parts. Statement keeps the cell offset
+  // between repeated calls on the same column.
+  if (colNum != statement->GetCurrentColNum()) {
+    statement->SetCurrentColNum(colNum);
+    statement->SetCellOffset(0);
+    dataBuffer.SetCellOffset(0);
+  } else {
+    dataBuffer.SetCellOffset(statement->GetCellOffset());
+  }
   statement->GetColumnData(colNum, dataBuffer);
+  statement->SetCellOffset(dataBuffer.GetCellOffset());
 
   return statement->GetDiagnosticRecords().GetReturnCode();
 }

--- a/src/odbc/src/query/data_query.cpp
+++ b/src/odbc/src/query/data_query.cpp
@@ -240,7 +240,7 @@ SqlResult::Type DataQuery::FetchNextRow(app::ColumnBindingMap& columnBindings) {
 
     if (it == columnBindings.end())
       continue;
-  
+
     app::ConversionResult::Type convRes =
         cursor_->ReadColumnToBuffer(i, it->second);
 

--- a/src/odbc/src/timestream_column.cpp
+++ b/src/odbc/src/timestream_column.cpp
@@ -71,7 +71,7 @@ ConversionResult::Type TimestreamColumn::ParseDatum(
   } else if (datum.RowValueHasBeenSet()) {
     retval = ParseRowType(datum, dataBuf);
   } else if (datum.NullValueHasBeenSet()) {
-    dataBuf.PutString("-");
+    dataBuf.PutNull();
     retval = ConversionResult::Type::AI_SUCCESS;
   } else {
     LOG_ERROR_MSG("Unsupported data type");
@@ -236,7 +236,7 @@ ConversionResult::Type TimestreamColumn::ParseArrayType(
 
   std::string result("");
   if (valueVec.empty()) {
-    result = "-";
+    result = "";
   } else {
     result = "[";
     for (const auto& itr : valueVec) {

--- a/src/odbc/src/timestream_cursor.cpp
+++ b/src/odbc/src/timestream_cursor.cpp
@@ -40,7 +40,7 @@ TimestreamCursor::~TimestreamCursor() {
 bool TimestreamCursor::Increment() {
   LOG_DEBUG_MSG("Increment is called");
 
-  if (curPos_ > 0) {
+  if (curPos_ > 0 && iterator_ < rowVec_.end()) {
     ++iterator_;
   }
   curPos_++;

--- a/src/tests/integration-test/src/attributes_test.cpp
+++ b/src/tests/integration-test/src/attributes_test.cpp
@@ -290,14 +290,12 @@ BOOST_AUTO_TEST_CASE(StatementAttributeCursorType) {
 }
 
 BOOST_AUTO_TEST_CASE(StatementAttributeRowArraySize) {
-  // check that statement array size cannot be set to values other than 1
+  // Check that statement array size can be set to values other than 1.
   ConnectToTS();
 
-  SQLINTEGER actual_row_array_size;
+  SQLULEN actual_row_array_size = 0;
   SQLINTEGER resLen = 0;
 
-  // check that statement array size cannot be set to values not equal to 1
-  // repeat test for different values
   SQLULEN val = 5;
   SQLRETURN ret =
       SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE,
@@ -427,6 +425,27 @@ BOOST_AUTO_TEST_CASE(StatementAttributeRowsFetchedPtr) {
   ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
 
   BOOST_REQUIRE_EQUAL(rowsFetchedPtr2[0], 1);
+}
+
+BOOST_AUTO_TEST_CASE(StatementAttributeRowsetSize) {
+  ConnectToTS();
+
+  SQLULEN actual_rowset_size;
+  SQLINTEGER resLen = 0;
+
+  SQLULEN val = 5;
+  SQLRETURN ret =
+    SQLSetStmtAttr(stmt, SQL_ROWSET_SIZE,
+      reinterpret_cast<SQLPOINTER>(val), sizeof(val));
+
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  ret = SQLGetStmtAttr(stmt, SQL_ROWSET_SIZE, reinterpret_cast<SQLPOINTER>(&actual_rowset_size),
+    sizeof(actual_rowset_size), &resLen);
+
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  BOOST_CHECK_EQUAL(actual_rowset_size, 5);
 }
 
 BOOST_AUTO_TEST_CASE(StatementAttributeRowsStatusesPtr) {
@@ -855,9 +874,6 @@ BOOST_AUTO_TEST_CASE(ConnectionSetConnectOptionUnsupportedValue) {
   BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
 
   ret = SQLSetConnectOption(dbc, SQL_RETRIEVE_DATA, SQL_RD_OFF);
-  BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
-
-  ret = SQLSetConnectOption(dbc, SQL_ROWSET_SIZE, 2000);
   BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
 }
 

--- a/src/tests/integration-test/src/queries_test.cpp
+++ b/src/tests/integration-test/src/queries_test.cpp
@@ -789,9 +789,9 @@ BOOST_AUTO_TEST_CASE(TestArraySingleResultUsingBindCol) {
                     utility::SqlCharToString(arrayChar1, arrayChar1_len));
   BOOST_CHECK_EQUAL(
       "[1,2,3]", utility::SqlWcharToString(arrayWchar1, arrayWchar1_len, true));
-  BOOST_CHECK_EQUAL("-", utility::SqlCharToString(arrayChar2, arrayChar2_len));
+  BOOST_CHECK_EQUAL("", utility::SqlCharToString(arrayChar2, arrayChar2_len));
   BOOST_CHECK_EQUAL(
-      "-", utility::SqlWcharToString(arrayWchar2, arrayWchar2_len, true));
+      "", utility::SqlWcharToString(arrayWchar2, arrayWchar2_len, true));
 }
 
 BOOST_AUTO_TEST_CASE(TestRowSingleResultUsingBindCol) {
@@ -839,14 +839,13 @@ BOOST_AUTO_TEST_CASE(TestNullSingleResultUsingBindCol) {
   if (!SQL_SUCCEEDED(ret)) {
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
   }
-
   const int32_t buf_size = 1024;
   SQLCHAR nullChar[buf_size]{};
   SQLLEN nullChar_len = 0;
 
   // fetch result as a string
   ret = SQLBindCol(stmt, 1, SQL_C_CHAR, nullChar, sizeof(nullChar),
-                   &nullChar_len);
+    &nullChar_len);
   BOOST_CHECK_EQUAL(SQL_SUCCESS, ret);
 
   SQLWCHAR nullWchar[buf_size]{};
@@ -854,15 +853,14 @@ BOOST_AUTO_TEST_CASE(TestNullSingleResultUsingBindCol) {
 
   // fetch result as a unicode string
   ret = SQLBindCol(stmt, 2, SQL_C_WCHAR, nullWchar, sizeof(nullWchar),
-                   &nullWchar_len);
+    &nullWchar_len);
   BOOST_CHECK_EQUAL(SQL_SUCCESS, ret);
 
   ret = SQLFetch(stmt);
   BOOST_CHECK_EQUAL(SQL_SUCCESS, ret);
 
-  BOOST_CHECK_EQUAL("-", utility::SqlCharToString(nullChar, nullChar_len));
-  BOOST_CHECK_EQUAL("-",
-                    utility::SqlWcharToString(nullWchar, nullWchar_len, true));
+  BOOST_CHECK_EQUAL(nullChar_len, SQL_NULL_DATA);
+  BOOST_CHECK_EQUAL(nullWchar_len, SQL_NULL_DATA);
 }
 
 BOOST_AUTO_TEST_CASE(TestSQLCancel) {
@@ -1476,16 +1474,15 @@ BOOST_AUTO_TEST_CASE(TestDefaultValues) {
   if (!SQL_SUCCEEDED(ret))
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-  // Checking that columns are not null.
+  // Checking that the first three columns are not null.
+  // flag, rebuffering_ratio, and video_startup_time will be null.
   for (SQLSMALLINT i = 0; i < 3; ++i)
     BOOST_CHECK_NE(columnLens[i], SQL_NULL_DATA);
 
-  BOOST_CHECK_EQUAL(defaultBoolColumn, false);
-  BOOST_CHECK_EQUAL(defaultDoubleColumn, 0.0);
-  BOOST_CHECK_EQUAL(defaultBigintColumn, 0);
-  BOOST_CHECK_EQUAL(columnLens[3], 1);
-  BOOST_CHECK_EQUAL(columnLens[4], 8);
-  BOOST_CHECK_EQUAL(columnLens[5], 8);
+  BOOST_CHECK_EQUAL(doubleColumn, 63.7);
+  BOOST_CHECK_EQUAL(columnLens[0], 8);
+  BOOST_CHECK_EQUAL(columnLens[1], 16);
+  BOOST_CHECK_EQUAL(columnLens[2], 8);
 
   ret = SQLFetch(stmt);
   BOOST_CHECK(ret == SQL_NO_DATA);


### PR DESCRIPTION
### Summary
<!--- General summary / title -->

Add OLE DB support

### Description
<!--- Details of what you changed -->

- Documentation for how the driver can be used with OLE DB, using PowerShell and Excel, has been added in its own file, `docs/markdown/setup/ole-db.md`.
- `src/out` has been added to `.gitignore`.
- Null is now returned for null values instead of the character "`-`".
- Empty arrays are represented as `[]` instead of `[-]`.
- `byteOffset` changed to `size_t`.
- `columnBindOffset` changed to `SqlUlen*`.
- `SQLExtendedFetch` implemented separately from `SQLFetchScroll` to support ODBC 2.x applications.
- `rowsetSize` added to `Statement`, for use with `SQLExtendedFetch`.
- `SQL_ROWSET_SIZE` is now handled in `Statement::InternalSetAttribute` and `Statement::InternalGetAttribute`.
- An `ignoreErrors` argument has been added to `InternalClose` so that `SQLFreeStmt` can ignore all errors when freeing.
- Restriction for array size being less than 1000 has been removed.
- Spelling errors have been fixed in comments and in the documentation.
- `SQLGetData` can now retrieve variable-length data in parts.
- Wth `SQLGetData`, the indicator pointer now receives the entire size of the cell if all data was placed in the buffer and gets the remaining data if only part of the data was placed in the buffer, when the buffer is too small to fit all data.

### Related Issue

Closes #10
Closes #11
Closes #12

### Additional Reviewers

N/A
