### PR TITLE
Fix SQLGetData retrieving data in parts

### DIFF
--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -319,7 +319,7 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   // resLenPtr will receive the remaining required data, gradually decreasing in length as
   // more calls with the same column are made.
   SqlLen remainingBytesRequired = bytesRequired - totalBytesWritten > 0 ?
-    static_cast<SqlLen>(bytesRequired - bytesWritten) : bytesRequired;
+    static_cast<SqlLen>(bytesRequired - totalBytesWritten) : bytesRequired;
   LOG_DEBUG_MSG("remainingBytesRequired is " << remainingBytesRequired);
 
   if (resLenPtr) {


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Fix SQLGetData retrieving data in parts

### Description

<!--- Details of what you changed -->

- SQLGetData now iterates through variable-length data, as it should.
- SQLGetData varchar tests have been changed to get data in much smaller parts and do a final comparison using a string reconstructed from parts with the full query result.

### Related Issue

<!--- Link to issue where this is tracked -->

N/A

### Additional Reviewers

<!-- Any additional reviewers -->

N/A
