### PR TITLE
Add workflow dispatch trigger for Windows GitHub action

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -1,6 +1,13 @@
 name: ODBC Driver for Windows
 
 on:
+  workflow_dispatch:
+    inputs:
+      sign:
+        description: 'Whether to sign the installers'
+        required: true
+        default: true
+        type: boolean
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v2.1.2](https://github.com/awslabs/amazon-timestream-odbc-driver/releases/tag/v2.1.2) - 2024-09-19
 
+### Added
+
+- [Add workflow dispatch trigger for Windows GitHub action](https://github.com/awslabs/amazon-timestream-odbc-driver/pull/25).
+
 ### Fixed
 
 - [Fix aws-sdk-cpp Dependency for Windows Builds](https://github.com/awslabs/amazon-timestream-odbc-driver/pull/23).


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Add workflow dispatch trigger for Windows GitHub action.

### Description

<!--- Details of what you changed -->

- A `workflow_dispatch` trigger has been added to the Windows GitHub action, meaning the action can be manually triggered with inputs, specifically, the `sign` input, which signs the Windows installers.
- CHANGELOG updated.

### Related Issue

<!--- Link to issue where this is tracked -->

N/A.

### Additional Reviewers

<!-- Any additional reviewers -->

N/A.
