### PR TITLE
Make TruffleHog scan entire branch

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sign:
-        description: 'Whether to sign the installers'
+        description: 'Sign installers'
         required: true
         default: true
         type: boolean
@@ -58,8 +58,8 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ""
+          head: ${{ github.ref_name }}
           extra_args: --debug --only-verified
       - name: git secrets
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Make TruffleHog scan entire branch](https://github.com/awslabs/amazon-timestream-odbc-driver/pull/26).
 - [Add workflow dispatch trigger for Windows GitHub action](https://github.com/awslabs/amazon-timestream-odbc-driver/pull/25).
 
 ### Fixed


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Make TruffleHog scan entire branch

### Description

<!--- Details of what you changed -->

- For the Windows GitHub action, TruffleHog will now scan an entire branch's history. This will allow TruffleHog to run when a PR is created and when actions are manually triggered on the main branch. Previously, manually triggered actions would fail, as the base and head commits for TruffleHog would be the same.
- Description for `sign` input simplified.
- CHANGELOG updated.

### Related Issue

<!--- Link to issue where this is tracked -->

N/A.

### Additional Reviewers

<!-- Any additional reviewers -->

N/A.
