### PR TITLE
Use separate keys for signing and testing

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -88,8 +88,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     # run unit tests
@@ -196,8 +196,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     # run unit tests

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -89,8 +89,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: run-unit-tests

--- a/.github/workflows/mac-debug-build.yml
+++ b/.github/workflows/mac-debug-build.yml
@@ -100,8 +100,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: run-unit-tests

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -203,7 +203,7 @@ jobs:
       run: |
         . ./scripts/sign_installer.ps1
         choco install jq -y
-        Invoke-SignInstaller build\odbc\cmake\Release x86 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
+        Invoke-SignInstaller build\odbc\cmake\Release x86 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_KEY }}
 
     - name: Upload ODBC driver build 
       uses: actions/upload-artifact@v4
@@ -344,7 +344,7 @@ jobs:
       run: |
         . ./scripts/sign_installer.ps1
         choco install jq -y
-        Invoke-SignInstaller build\odbc\cmake\Release x64 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
+        Invoke-SignInstaller build\odbc\cmake\Release x64 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_KEY }}
 
     - name: Upload ODBC driver build 
       uses: actions/upload-artifact@v4

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -129,8 +129,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: run-unit-tests
@@ -188,11 +188,11 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-skip-session-tagging: true
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_SIGNING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+        role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_TO_ASSUME }}
+        role-external-id: ${{ secrets.AWS_SIGNING_ROLE_EXTERNAL_ID }}
         role-duration-seconds: 3600
 
     # Name of signed executable is same as unsigned exeuctable
@@ -203,7 +203,7 @@ jobs:
       run: |
         . ./scripts/sign_installer.ps1
         choco install jq -y
-        Invoke-SignInstaller build\odbc\cmake\Release x86 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_KEY }}
+        Invoke-SignInstaller build\odbc\cmake\Release x86 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
 
     - name: Upload ODBC driver build 
       uses: actions/upload-artifact@v4
@@ -270,8 +270,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: run-unit-tests
@@ -329,11 +329,11 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-skip-session-tagging: true
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_SIGNING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+        role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_TO_ASSUME }}
+        role-external-id: ${{ secrets.AWS_SIGNING_ROLE_EXTERNAL_ID }}
         role-duration-seconds: 3600
 
     # Name of signed executable is same as unsigned exeuctable
@@ -344,7 +344,7 @@ jobs:
       run: |
         . ./scripts/sign_installer.ps1
         choco install jq -y
-        Invoke-SignInstaller build\odbc\cmake\Release x64 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_KEY }}
+        Invoke-SignInstaller build\odbc\cmake\Release x64 ${{ steps.getversion.outputs.version }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
 
     - name: Upload ODBC driver build 
       uses: actions/upload-artifact@v4
@@ -411,8 +411,8 @@ jobs:
       if: success()
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_IT_TEST_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_IT_TEST_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: run-tests


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Use separate keys for signing and testing.

### Description

<!--- Details of what you changed -->

- The names of the secrets for integration testing has been changed as follows:
  - `AWS_IT_TEST_ACCESS_KEY_ID`
  - `AWS_IT_TEST_SECRET_ACCESS_KEY`

- The names of the secrets for signing Windows installers has been changed as follows:
  - `AWS_SIGNING_ACCESS_KEY_ID`
  - `AWS_SIGNING_SECRET_ACCESS_KEY`
  - `AWS_SIGNING_ROLE_TO_ASSUME`
  - `AWS_SIGNING_ROLE_EXTERNAL_ID`

### Related Issue

<!--- Link to issue where this is tracked -->

N/A.

### Additional Reviewers

<!-- Any additional reviewers -->

N/A.
