### PR TITLE
Undo changes to assumed role secret names

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -193,8 +193,8 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_SIGNING_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_TO_ASSUME }}
-        role-external-id: ${{ secrets.AWS_SIGNING_ROLE_EXTERNAL_ID }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
         role-duration-seconds: 3600
 
     # Name of signed executable is same as unsigned exeuctable
@@ -336,8 +336,8 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_SIGNING_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SIGNING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_TO_ASSUME }}
-        role-external-id: ${{ secrets.AWS_SIGNING_ROLE_EXTERNAL_ID }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
         role-duration-seconds: 3600
 
     # Name of signed executable is same as unsigned exeuctable


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Undo changes to assumed role secret names.

### Description

<!--- Details of what you changed -->

- Assumed role name used for signing Windows installers reverted to `AWS_ROLE_TO_ASSUME`.
- Assumed role external ID name used for signing Windows installers reverted to `AWS_ROLE_EXTERNAL_ID`.

### Related Issue

<!--- Link to issue where this is tracked -->

N/A.

### Additional Reviewers

<!-- Any additional reviewers -->

N/A.
