### PR TITLE
Replace wstring conversion with `mbstowcs`

### DIFF
--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -260,10 +260,7 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   if (ANSI_STRING_ONLY) {
     bytesRequired = value.length() * outCharSize;
   } else {
-    thread_local std::wstring_convert<std::codecvt_utf8<wchar_t >, wchar_t>
-      converter;
-    std::wstring inString = converter.from_bytes(value.c_str());
-    bytesRequired = inString.length() * outCharSize;
+    bytesRequired = (std::mbstowcs(nullptr, value.c_str(), 0) * outCharSize);
   }
 
   SqlLen* resLenPtr = GetResLen();


### PR DESCRIPTION
### Summary

`ApplicationDataBuffer::PutStrToStrBuffer` performs a conversion and copy, but the conversion is only done to calculate the length of the buffer.

### Description

By using `mbstowcs`, we can count the number of wide chars without performing the full conversion.

- [x] Unit tests passed
- [x] IT tests passed
- [x] Test with Excel
![Screenshot 2025-01-17 at 11 17 13 AM](https://github.com/user-attachments/assets/ae223ddd-8d70-4236-a705-1baea5147572)

### Related Issue

NA

### Additional Reviewers

NA