### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -36,6 +36,11 @@ env:
   # OKTA_ROLE_ARN: ${{secrets.OKTA_ROLE_ARN}}
   # OKTA_IDP_ARN: ${{secrets.OKTA_IDP_ARN}}  
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build-linux64:
     runs-on: ubuntu-20.04

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -38,6 +38,11 @@ env:
   # OKTA_ROLE_ARN: ${{secrets.OKTA_ROLE_ARN}}
   # OKTA_IDP_ARN: ${{secrets.OKTA_IDP_ARN}}  
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build-mac:
     runs-on: macos-12

--- a/.github/workflows/mac-debug-build.yml
+++ b/.github/workflows/mac-debug-build.yml
@@ -38,6 +38,11 @@ env:
   # OKTA_ROLE_ARN: ${{secrets.OKTA_ROLE_ARN}}
   # OKTA_IDP_ARN: ${{secrets.OKTA_IDP_ARN}}  
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build-mac-debug:
     runs-on: macos-12

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -20,6 +20,9 @@ on:
     # Every day at 1am
     - cron: '0 1 * * *'
 
+permissions:
+  actions: write
+
 jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -46,6 +46,11 @@ env:
   # OKTA_ROLE_ARN: ${{secrets.OKTA_ROLE_ARN}}
   # OKTA_IDP_ARN: ${{secrets.OKTA_IDP_ARN}}  
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   trufflehog-git-secrets-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.